### PR TITLE
feat: Add types to options

### DIFF
--- a/src/CLI.cpp
+++ b/src/CLI.cpp
@@ -26,6 +26,7 @@
 
 #include <ranges>
 #include <regex>
+#include <typeindex>
 #include <utility>
 
 using namespace yeschief;
@@ -34,33 +35,7 @@ CLI::CLI(std::string name, std::string description): _name(std::move(name)), _de
     _groups.insert(std::make_pair("", OptionGroup(this)));
 }
 
-auto CLI::addOption(const std::string &name, const std::string &description, const OptionConfiguration &configuration)
-    -> CLI & {
-    if (_options.contains(name)) {
-        throw std::logic_error("CLI has already an option '" + name + "'");
-    }
-
-    std::string long_name = name;
-    std::string short_name;
-    const std::regex name_regex("(.*),(.*)");
-    if (std::smatch match; std::regex_match(name, match, name_regex)) {
-        if (match.size() == 3) {
-            long_name  = match[1].str();
-            short_name = match[2].str();
-            if (short_name.length() != 1 || ! isalpha(short_name[0])) {
-                throw std::logic_error("Short name of an option can be only one letter, got '" + short_name + "'");
-            }
-        }
-    }
-
-    auto option = std::make_shared<Option>(long_name, short_name, description, configuration.required);
-    _options.insert(std::make_pair(long_name, option));
-    _groups.at("").addOption(option);
-
-    return *this;
-}
-
-auto CLI::run(int argc, char **argv) const -> std::expected<CLIResults, Fault> {
+auto CLI::run(const int argc, char **argv) const -> std::expected<CLIResults, Fault> {
     if (argc < 1) {
         return std::unexpected<Fault>({
           .message = "argc cannot be less than 1, argv should at least contains executable name",
@@ -68,51 +43,62 @@ auto CLI::run(int argc, char **argv) const -> std::expected<CLIResults, Fault> {
         });
     }
 
-    // Skip program name
-    argc--;
-    argv++;
-
-    std::map<std::string, std::any> option_values;
-    while (argc > 0) {
-        const std::string argument(argv[0]);
-        if (argument.starts_with("--")) {
-            const auto long_name = argument.substr(2);
-            if (! _options.contains(long_name)) {
-                return std::unexpected<Fault>({
-                  .message = "Unrecognized option: " + argument,
-                  .type    = UnrecognizedOption,
-                });
-            }
-            option_values[long_name] = true;
-        } else if (argument.starts_with("-")) {
-            const auto short_name = argument.substr(1);
-            const auto find       = std::ranges::find_if(_options, [&short_name](const auto &option) {
-                return ! option.second->getShortName().empty() && option.second->getShortName() == short_name;
-            });
-            if (find == _options.end()) {
-                return std::unexpected<Fault>({
-                  .message = "Unrecognized option: " + argument,
-                  .type    = UnrecognizedOption,
-                });
-            }
-            option_values[find->second->getName()] = true;
-        } else {
-            return std::unexpected<Fault>({
-              .message = "Unrecognized option: " + argument,
-              .type    = UnrecognizedOption,
-            });
-        }
-
-        argc--;
-        argv++;
+    std::vector<std::string> allowed_options;
+    for (const auto &option : _options | std::ranges::views::values) {
+        allowed_options.push_back(option->getName());
+        allowed_options.push_back(option->getShortName());
     }
-
+    const auto parse_results_expect = parseArgv(argc - 1, argv + 1, allowed_options);
+    if (! parse_results_expect.has_value()) {
+        return std::unexpected(parse_results_expect.error());
+    }
+    const auto &[raw_results, option_order] = parse_results_expect.value();
+    std::map<std::string, std::any> option_values;
     std::vector<std::string> missing_required;
     for (const auto &option : _options | std::ranges::views::values) {
-        if (option->isRequired() && ! option_values.contains(option->getName())) {
+        if (raw_results.contains(option->getName()) && raw_results.contains(option->getShortName())) {
+            auto long_values_it  = raw_results.at(option->getName()).begin();
+            auto short_values_it = raw_results.at(option->getShortName()).begin();
+            std::vector<std::string> values;
+            // Assert that long_values.length + short_values.length === option_orders of (-n, --name).
+            // If it is not the case it means there is a bug in parseArgv and it should be fixed
+            for (const auto &oo : option_order) {
+                if (oo == option->getName()) {
+                    values.push_back(*long_values_it++);
+                } else if (oo == option->getShortName()) {
+                    values.push_back(*short_values_it++);
+                }
+            }
+            auto value = getValueForOption(option, values);
+            if (! value.has_value()) {
+                return std::unexpected(value.error());
+            }
+            option_values.insert(std::make_pair(option->getName(), value.value()));
+        }
+
+        else if (raw_results.contains(option->getName())) {
+            auto values = raw_results.at(option->getName());
+            auto value  = getValueForOption(option, values);
+            if (! value.has_value()) {
+                return std::unexpected(value.error());
+            }
+            option_values.insert(std::make_pair(option->getName(), value.value()));
+        }
+
+        else if (raw_results.contains(option->getShortName())) {
+            auto values = raw_results.at(option->getShortName());
+            auto value  = getValueForOption(option, values);
+            if (! value.has_value()) {
+                return std::unexpected(value.error());
+            }
+            option_values.insert(std::make_pair(option->getName(), value.value()));
+        }
+
+        else if (option->getConfiguration().required) {
             missing_required.push_back(option->getName());
         }
     }
+
     if (! missing_required.empty()) {
         return std::unexpected<Fault>({
           .message = "Some required options were not given: " + join(missing_required, ", "),
@@ -122,6 +108,87 @@ auto CLI::run(int argc, char **argv) const -> std::expected<CLIResults, Fault> {
 
     CLIResults results(option_values);
     return results;
+}
+
+template<typename T> auto toAny(std::expected<T, Fault> exp) -> std::expected<std::any, Fault> {
+    return exp.transform([](const auto &value) {
+        return std::any(value);
+    });
+}
+
+auto CLI::getValueForOption(const std::shared_ptr<Option> &option, const std::vector<std::string> &values)
+    -> std::expected<std::any, Fault> {
+    const auto last_index = values.size() - 1;
+    if (option->getType() == typeid(bool)) {
+        return toAny(toBoolean(values[last_index]));
+    }
+    if (option->getType() == typeid(std::string)) {
+        return values[last_index];
+    }
+    if (option->getType() == typeid(int)) {
+        return toAny(toInt(values[last_index]));
+    }
+    if (option->getType() == typeid(float)) {
+        return toAny(toFloat(values[last_index]));
+    }
+    if (option->getType() == typeid(double)) {
+        return toAny(toDouble(values[last_index]));
+    }
+    if (option->getType() == typeid(std::vector<bool>)) {
+        std::vector<bool> bool_results;
+        bool_results.reserve(values.size());
+        for (const auto &string_value : values) {
+            const auto value = toBoolean(string_value);
+            if (! value.has_value()) {
+                return std::unexpected(value.error());
+            }
+            bool_results.push_back(value.value());
+        }
+        return bool_results;
+    }
+    if (option->getType() == typeid(std::vector<std::string>)) {
+        return values;
+    }
+    if (option->getType() == typeid(std::vector<int>)) {
+        std::vector<int> int_results;
+        int_results.reserve(values.size());
+        for (const auto &string_value : values) {
+            const auto value = toInt(string_value);
+            if (! value.has_value()) {
+                return std::unexpected(value.error());
+            }
+            int_results.push_back(value.value());
+        }
+        return int_results;
+    }
+    if (option->getType() == typeid(std::vector<float>)) {
+        std::vector<float> float_results;
+        float_results.reserve(values.size());
+        for (const auto &string_value : values) {
+            const auto value = toFloat(string_value);
+            if (! value.has_value()) {
+                return std::unexpected(value.error());
+            }
+            float_results.push_back(value.value());
+        }
+        return float_results;
+    }
+    if (option->getType() == typeid(std::vector<double>)) {
+        std::vector<double> double_results;
+        double_results.reserve(values.size());
+        for (const auto &string_value : values) {
+            const auto value = toDouble(string_value);
+            if (! value.has_value()) {
+                return std::unexpected(value.error());
+            }
+            double_results.push_back(value.value());
+        }
+        return double_results;
+    }
+
+    throw std::runtime_error(
+        "Type '" + std::string(option->getType().name()) + "' is not allowed. It should have been caught before"
+    );
 }
 
 auto CLI::help(std::ostream &out) const -> void {
@@ -140,15 +207,9 @@ auto CLI::help(std::ostream &out) const -> void {
             << "\n";
 
         for (const auto &option : group._options) {
-            out << "\t--" << option->getName();
-            if (! option->getShortName().empty()) {
-                out << ", -" << option->getShortName();
-            }
-            if (option->isRequired()) {
-                out << " REQUIRED";
-            }
-            out << "\n"
-                << "\t\t" << join(split(option->getDescription(), "\n"), "\n\t\t") << "\n";
+            out << "\t" << buildOptionUsageHelp(option) << "\n"
+                << "\t\t" << join(split(option->getDescription(), "\n"), "\n\t\t") << "\n"
+                << "\n";
         }
     }
 }
@@ -160,10 +221,37 @@ auto CLI::buildUsageHelp() const -> std::string {
         usage += " [OPTIONS]";
     }
     for (const auto &option : _options | std::ranges::views::values) {
-        if (option->isRequired()) {
+        if (option->getConfiguration().required) {
             usage += " --" + option->getName();
         }
     }
 
     return usage;
+}
+
+auto CLI::buildOptionUsageHelp(const std::shared_ptr<Option> &option) -> std::string {
+    auto usage = "--" + option->getName();
+    if (option->getType() != typeid(bool)) {
+        usage += " " + option->getConfiguration().value_help;
+    }
+    if (! option->getShortName().empty()) {
+        usage += ", -" + option->getShortName();
+        if (option->getType() != typeid(bool)) {
+            usage += " " + option->getConfiguration().value_help;
+        }
+    }
+    if (option->getConfiguration().required) {
+        usage += " [REQUIRED]";
+    }
+
+    return usage;
+}
+
+auto CLI::checkOptionType(const std::type_info &type) -> void {
+    if (type != typeid(bool) && type != typeid(std::string) && type != typeid(int) && type != typeid(float)
+        && type != typeid(double) && type != typeid(std::vector<bool>) && type != typeid(std::vector<std::string>)
+        && type != typeid(std::vector<int>) && type != typeid(std::vector<float>)
+        && type != typeid(std::vector<double>)) {
+        throw std::logic_error("Type '" + std::string(type.name()) + "' is not allowed for options");
+    }
 }

--- a/src/Option.cpp
+++ b/src/Option.cpp
@@ -26,9 +26,13 @@
 using namespace yeschief;
 
 Option::Option(
-    const std::string &name, const std::string &short_name, const std::string &description, const bool required
+    const std::string &name,
+    const std::string &short_name,
+    const std::string &description,
+    const std::type_info &type,
+    const OptionConfiguration &configuration
 )
-    : _name(name), _short_name(short_name), _description(description), _required(required) {}
+    : _name(name), _short_name(short_name), _description(description), _type(type), _configuration(configuration) {}
 
 auto Option::getName() const -> std::string {
     return _name;
@@ -42,6 +46,10 @@ auto Option::getDescription() const -> std::string {
     return _description;
 }
 
-auto Option::isRequired() const -> bool {
-    return _required;
+auto Option::getType() const -> const std::type_info & {
+    return _type;
+}
+
+auto Option::getConfiguration() const -> OptionConfiguration {
+    return _configuration;
 }

--- a/src/utils.cpp
+++ b/src/utils.cpp
@@ -53,3 +53,134 @@ auto yeschief::split(const std::string &str, const std::string &delimiter) -> st
 
     return result;
 }
+
+auto yeschief::parseArgv(const int argc, char **argv, const std::vector<std::string> &allowed_options)
+    -> std::expected<ArgvParsingResult, Fault> {
+    auto count     = argc;
+    auto arguments = argv;
+    std::map<std::string, std::vector<std::string>> raw_results;
+    std::vector<std::string> option_order;
+    const auto in_allowed_option = [&allowed_options](const std::string &option) -> bool {
+        return std::ranges::find(allowed_options, option) != allowed_options.end();
+    };
+
+    std::optional<std::string> current_option = std::nullopt;
+    while (count > 0) {
+        const auto argument = std::string(arguments[0]);
+        std::smatch match;
+        if (std::regex_match(argument, match, std::regex("^--([^=]*)=([^=]*)$"))
+            || std::regex_match(argument, match, std::regex("^-([^=])=([^=]*)$"))) {
+            if (current_option.has_value()) {
+                raw_results.at(current_option.value()).emplace_back("true");
+            }
+
+            const std::string option = match[1];
+            if (! in_allowed_option(option)) {
+                return std::unexpected<Fault>({
+                  .message = "Unrecognized option: " + option,
+                  .type    = UnrecognizedOption,
+                });
+            }
+            if (! raw_results.contains(option)) {
+                raw_results.insert(std::make_pair(option, std::vector<std::string>()));
+            }
+
+            std::string value = match[2];
+            if (std::smatch value_match; std::regex_match(value, value_match, std::regex("^(['\"])(.*)\\1$"))) {
+                value = value_match[2];
+            }
+
+            raw_results.at(option).push_back(value);
+            option_order.push_back(option);
+            current_option = std::nullopt;
+        }
+
+        else if (std::regex_match(argument, match, std::regex("^--([^=]*)$"))
+                 || std::regex_match(argument, match, std::regex("^-([^=])$"))) {
+            if (current_option.has_value()) {
+                raw_results.at(current_option.value()).emplace_back("true");
+            }
+
+            const std::string option = match[1];
+            if (! in_allowed_option(option)) {
+                return std::unexpected<Fault>({
+                  .message = "Unrecognized option: " + option,
+                  .type    = UnrecognizedOption,
+                });
+            }
+            current_option = option;
+            if (! raw_results.contains(option)) {
+                raw_results.insert(std::make_pair(option, std::vector<std::string>()));
+            }
+            option_order.push_back(option);
+        }
+
+        else {
+            if (current_option.has_value()) {
+                raw_results.at(current_option.value()).push_back(argument);
+                current_option = std::nullopt;
+            } else {
+                return std::unexpected<Fault>({
+                  .message = "Unrecognized option: " + argument,
+                  .type    = UnrecognizedOption,
+                });
+            }
+        }
+
+        count--;
+        arguments++;
+    }
+
+    if (current_option.has_value()) {
+        raw_results.at(current_option.value()).emplace_back("true");
+    }
+
+    ArgvParsingResult parse_result = {
+      .raw_results  = raw_results,
+      .option_order = option_order,
+    };
+    return parse_result;
+}
+
+auto yeschief::toBoolean(const std::string &value) -> std::expected<bool, Fault> {
+    if (value == "true" || value == "1") {
+        return true;
+    }
+    if (value == "false" || value == "0") {
+        return false;
+    }
+    return std::unexpected<Fault>({
+      .message = "'" + value + "' cannot be parsed to a boolean value",
+      .type    = InvalidOptionType,
+    });
+}
+
+auto yeschief::toInt(const std::string &value) -> std::expected<int, Fault> {
+    if (std::smatch match; std::regex_match(value, match, std::regex("^[+-]?\\d+$"))) {
+        return std::stoi(value);
+    }
+    return std::unexpected<Fault>({
+      .message = "'" + value + "' cannot be parsed to an int value",
+      .type    = InvalidOptionType,
+    });
+}
+
+auto yeschief::toFloat(const std::string &value) -> std::expected<float, Fault> {
+    if (std::smatch match; std::regex_match(value, match, std::regex("^[+-]?([0-9]*[.])?[0-9]+$"))) {
+        return std::stof(value);
+    }
+    return std::unexpected<Fault>({
+      .message = "'" + value + "' cannot be parsed to an int value",
+      .type    = InvalidOptionType,
+    });
+}
+
+auto yeschief::toDouble(const std::string &value) -> std::expected<double, Fault> {
+    if (std::smatch match; std::regex_match(value, match, std::regex("^[+-]?([0-9]*[.])?[0-9]+$"))) {
+        return std::stod(value);
+    }
+    return std::unexpected<Fault>({
+      .message = "'" + value + "' cannot be parsed to an int value",
+      .type    = InvalidOptionType,
+    });
+}

--- a/src/utils.h
+++ b/src/utils.h
@@ -24,6 +24,10 @@
 #ifndef UTILS_H
 #define UTILS_H
 
+#include "yeschief.h"
+
+#include <expected>
+#include <map>
 #include <string>
 #include <vector>
 
@@ -31,6 +35,22 @@ namespace yeschief {
 auto join(const std::vector<std::string> &strings, const std::string &delimiter = "") -> std::string;
 
 auto split(const std::string &str, const std::string &delimiter) -> std::vector<std::string>;
+
+typedef struct {
+    std::map<std::string, std::vector<std::string>> raw_results;
+    std::vector<std::string> option_order;
+} ArgvParsingResult;
+
+auto parseArgv(int argc, char **argv, const std::vector<std::string> &allowed_options)
+    -> std::expected<ArgvParsingResult, Fault>;
+
+auto toBoolean(const std::string &value) -> std::expected<bool, Fault>;
+
+auto toInt(const std::string &value) -> std::expected<int, Fault>;
+
+auto toFloat(const std::string &value) -> std::expected<float, Fault>;
+
+auto toDouble(const std::string &value) -> std::expected<double, Fault>;
 } // namespace yeschief
 
 #endif // UTILS_H

--- a/tests/unit/OptionTest.cpp
+++ b/tests/unit/OptionTest.cpp
@@ -25,9 +25,10 @@
 #include <yeschief.h>
 
 TEST(Option, constructor) {
-    const yeschief::Option option("help", "h", "Some description", false);
+    const yeschief::Option option("help", "h", "Some description", typeid(bool), {.required = false});
     ASSERT_STREQ("help", option.getName().c_str());
     ASSERT_STREQ("h", option.getShortName().c_str());
     ASSERT_STREQ("Some description", option.getDescription().c_str());
-    ASSERT_FALSE(option.isRequired());
+    ASSERT_EQ(typeid(bool), option.getType());
+    ASSERT_FALSE(option.getConfiguration().required);
 }

--- a/tests/unit/utilsTest.cpp
+++ b/tests/unit/utilsTest.cpp
@@ -23,6 +23,8 @@
  */
 #include "../../src/utils.h"
 
+#include "test_tools.hpp"
+
 #include <gmock/gmock.h>
 #include <gtest/gtest.h>
 
@@ -58,4 +60,154 @@ TEST(utils, splitOnSpaceNoEmpty) {
 
 TEST(utils, splitOnLongString) {
     ASSERT_THAT(yeschief::split("ahellobhelloc", "hello"), ElementsAre("a", "b", "c"));
+}
+
+TEST(utils, parseArgvEmptyReturnsEmpty) {
+    const auto &[raw_results, option_order] = yeschief::parseArgv(0, {}, {}).value();
+    ASSERT_THAT(raw_results, IsEmpty());
+    ASSERT_THAT(option_order, IsEmpty());
+}
+
+TEST(utils, parseArgvSimpleLongOption) {
+    ASSERT_THAT(
+        yeschief::parseArgv(1, toStringArray({"--name"}).data(), {"name"}).value().raw_results,
+        ElementsAre(Pair("name", ElementsAre("true")))
+    );
+}
+
+TEST(utils, parseArgvLongOptionEqualValue) {
+    ASSERT_THAT(
+        yeschief::parseArgv(1, toStringArray({"--name=value"}).data(), {"name"}).value().raw_results,
+        ElementsAre(Pair("name", ElementsAre("value")))
+    );
+}
+
+TEST(utils, parseArgvLongOptionEqualStringValue) {
+    ASSERT_THAT(
+        yeschief::parseArgv(1, toStringArray({"--name='value'"}).data(), {"name"}).value().raw_results,
+        ElementsAre(Pair("name", ElementsAre("value")))
+    );
+    ASSERT_THAT(
+        yeschief::parseArgv(1, toStringArray({"--name=\"value\""}).data(), {"name"}).value().raw_results,
+        ElementsAre(Pair("name", ElementsAre("value")))
+    );
+}
+
+TEST(utils, parseArgvLongOptionWithValue) {
+    ASSERT_THAT(
+        yeschief::parseArgv(2, toStringArray({"--name", "value"}).data(), {"name"}).value().raw_results,
+        ElementsAre(Pair("name", ElementsAre("value")))
+    );
+}
+
+TEST(utils, parseArgvLongOptionWithValues) {
+    ASSERT_THAT(
+        yeschief::parseArgv(4, toStringArray({"--name", "value1", "--name", "value2"}).data(), {"name"})
+            .value()
+            .raw_results,
+        ElementsAre(Pair("name", ElementsAre("value1", "value2")))
+    );
+}
+
+TEST(utils, parseArgvSimpleShortOption) {
+    ASSERT_THAT(
+        yeschief::parseArgv(1, toStringArray({"-n"}).data(), {"n"}).value().raw_results,
+        ElementsAre(Pair("n", ElementsAre("true")))
+    );
+}
+
+TEST(utils, parseArgvShortOptionEqualValue) {
+    ASSERT_THAT(
+        yeschief::parseArgv(1, toStringArray({"-n=value"}).data(), {"n"}).value().raw_results,
+        ElementsAre(Pair("n", ElementsAre("value")))
+    );
+}
+
+TEST(utils, parseArgvShortOptionEqualStringValue) {
+    ASSERT_THAT(
+        yeschief::parseArgv(1, toStringArray({"-n='value'"}).data(), {"n"}).value().raw_results,
+        ElementsAre(Pair("n", ElementsAre("value")))
+    );
+    ASSERT_THAT(
+        yeschief::parseArgv(1, toStringArray({"-n=\"value\""}).data(), {"n"}).value().raw_results,
+        ElementsAre(Pair("n", ElementsAre("value")))
+    );
+}
+
+TEST(utils, parseArgvShortOptionWithValue) {
+    ASSERT_THAT(
+        yeschief::parseArgv(2, toStringArray({"-n", "value"}).data(), {"n"}).value().raw_results,
+        ElementsAre(Pair("n", ElementsAre("value")))
+    );
+}
+
+TEST(utils, parseArgvShortOptionWithValues) {
+    ASSERT_THAT(
+        yeschief::parseArgv(4, toStringArray({"-n", "value1", "-n", "value2"}).data(), {"n"}).value().raw_results,
+        ElementsAre(Pair("n", ElementsAre("value1", "value2")))
+    );
+}
+
+TEST(utils, parseArgvMultipleOptions) {
+    const auto [raw_results, option_order]
+        = yeschief::parseArgv(3, toStringArray({"-n", "value", "--number=3"}).data(), {"n", "number"}).value();
+    ASSERT_THAT(raw_results, ElementsAre(Pair("n", ElementsAre("value")), Pair("number", ElementsAre("3"))));
+    ASSERT_THAT(option_order, ElementsAre("n", "number"));
+}
+
+TEST(utils, parseArgvSetTrueWhenNoValue) {
+    ASSERT_THAT(
+        yeschief::parseArgv(1, toStringArray({"-n"}).data(), {"n"}).value().raw_results,
+        ElementsAre(Pair("n", ElementsAre("true")))
+    );
+    ASSERT_THAT(
+        yeschief::parseArgv(2, toStringArray({"-n", "--version"}).data(), {"n", "version"}).value().raw_results,
+        ElementsAre(Pair("n", ElementsAre("true")), Pair("version", ElementsAre("true")))
+    );
+}
+
+TEST(utils, parseArgvFaultWhenValueGivenWithoutOption) {
+    const auto result = yeschief::parseArgv(1, toStringArray({"value"}).data(), {});
+    ASSERT_FALSE(result.has_value());
+    ASSERT_EQ(yeschief::FaultType::UnrecognizedOption, result.error().type);
+}
+
+TEST(utils, parseArgvFaultWhenOptionIsNotAllowed) {
+    const auto result = yeschief::parseArgv(1, toStringArray({"--option"}).data(), {});
+    ASSERT_FALSE(result.has_value());
+    ASSERT_EQ(yeschief::FaultType::UnrecognizedOption, result.error().type);
+}
+
+TEST(utils, toBoolean) {
+    ASSERT_TRUE(yeschief::toBoolean("true").value());
+    ASSERT_TRUE(yeschief::toBoolean("1").value());
+    ASSERT_FALSE(yeschief::toBoolean("false").value());
+    ASSERT_FALSE(yeschief::toBoolean("0").value());
+    ASSERT_EQ(yeschief::FaultType::InvalidOptionType, yeschief::toBoolean("foobar").error().type);
+}
+
+TEST(utils, toInt) {
+    ASSERT_EQ(1, yeschief::toInt("1").value());
+    ASSERT_EQ(1, yeschief::toInt("+1").value());
+    ASSERT_EQ(123456, yeschief::toInt("123456").value());
+    ASSERT_EQ(-2, yeschief::toInt("-2").value());
+    ASSERT_EQ(yeschief::FaultType::InvalidOptionType, yeschief::toInt("blabla").error().type);
+}
+
+TEST(utils, toFloat) {
+    ASSERT_EQ(1.0f, yeschief::toFloat("1").value());
+    ASSERT_EQ(0.1f, yeschief::toFloat(".1").value());
+    ASSERT_EQ(0.1f, yeschief::toFloat("0.1").value());
+    ASSERT_EQ(-3.4f, yeschief::toFloat("-3.4").value());
+    ASSERT_EQ(.81f, yeschief::toFloat("+.81").value());
+    ASSERT_EQ(yeschief::FaultType::InvalidOptionType, yeschief::toFloat("hello").error().type);
+}
+
+TEST(utils, toDouble) {
+    ASSERT_EQ(1.0, yeschief::toDouble("1").value());
+    ASSERT_EQ(0.1, yeschief::toDouble(".1").value());
+    ASSERT_EQ(0.1, yeschief::toDouble("0.1").value());
+    ASSERT_EQ(-3.4, yeschief::toDouble("-3.4").value());
+    ASSERT_EQ(.81, yeschief::toDouble("+.81").value());
+    ASSERT_EQ(yeschief::FaultType::InvalidOptionType, yeschief::toDouble("world").error().type);
 }


### PR DESCRIPTION
Closes #11

Options are no longer limited to bool, a set of type (string, int, float, double and their vector variations) are now allowed to be used as template parameter to addOption

It means that an option can be of type int and its value be any signed integer -> `--truth 42`