### PR TITLE
refactor: emplace + at -> emplace

### DIFF
--- a/src/CLI.cpp
+++ b/src/CLI.cpp
@@ -46,8 +46,7 @@ auto CLI::addGroup(const std::string &name) -> OptionGroup & {
         throw std::logic_error("Group '" + name + "' already exists");
     }
 
-    _groups.emplace(name, OptionGroup(this, name));
-    return _groups.at(name);
+    return _groups.emplace(name, OptionGroup(this, name)).first->second;
 }
 
 auto CLI::addCommand(Command *command) -> CLI & {


### PR DESCRIPTION
Closes #41

Instead of doing `map.emplace` then `map.at`, just do `map.emplace.blabla`. Emplace returns a pair with first element containing the map pair, so first->second contains the inserted element