### PR TITLE
feat: Replace throw by assert

### DIFF
--- a/src/CLI.cpp
+++ b/src/CLI.cpp
@@ -37,28 +37,24 @@ CLI::CLI(std::string name, std::string description)
 }
 
 auto CLI::addGroup(const std::string &name) -> OptionGroup & {
-    if (_mode.has_value() && _mode.value() == Mode::COMMANDS) {
-        throw std::logic_error("Cannot add an option group to a cli using commands");
-    }
+    assert_message(
+        ! _mode.has_value() || _mode.value() != Mode::COMMANDS, "Cannot add an option group to a cli using commands"
+    );
     _mode = Mode::OPTIONS;
 
-    if (_groups.contains(name)) {
-        throw std::logic_error("Group '" + name + "' already exists");
-    }
+    assert_message(! _groups.contains(name), "Group already exists");
 
     return _groups.emplace(name, OptionGroup(this, name)).first->second;
 }
 
 auto CLI::addCommand(Command *command) -> CLI & {
-    if (_mode.has_value() && _mode.value() == Mode::OPTIONS) {
-        throw std::logic_error("Cannot add a command to a cli using options");
-    }
+    assert_message(
+        ! _mode.has_value() || _mode.value() != Mode::OPTIONS, "Cannot add a command to a cli using options"
+    );
     _mode = Mode::COMMANDS;
 
     const auto name = command->getName();
-    if (_commands.contains(name)) {
-        throw std::logic_error("Command '" + name + "' already exists");
-    }
+    assert_message(! _commands.contains(name), "Command already exists");
 
     CLI command_cli(name, command->getDescription());
     command->setup(command_cli);
@@ -427,10 +423,11 @@ auto CLI::buildOptionUsageHelp(const std::shared_ptr<const Option> &option) -> s
 }
 
 auto CLI::checkOptionType(const std::type_info &type) -> void {
-    if (type != typeid(bool) && type != typeid(std::string) && type != typeid(int) && type != typeid(float)
-        && type != typeid(double) && type != typeid(std::vector<bool>) && type != typeid(std::vector<std::string>)
-        && type != typeid(std::vector<int>) && type != typeid(std::vector<float>)
-        && type != typeid(std::vector<double>)) {
-        throw std::logic_error("Type '" + std::string(type.name()) + "' is not allowed for options");
-    }
+    assert_message(
+        type == typeid(bool) || type == typeid(std::string) || type == typeid(int) || type == typeid(float)
+            || type == typeid(double) || type == typeid(std::vector<bool>) || type == typeid(std::vector<std::string>)
+            || type == typeid(std::vector<int>) || type == typeid(std::vector<float>)
+            || type == typeid(std::vector<double>),
+        "Type is not allowed for options"
+    );
 }

--- a/tests/unit/CLITest.cpp
+++ b/tests/unit/CLITest.cpp
@@ -41,7 +41,11 @@ TEST(CLI, addOptionWithShortName) {
 
 TEST(CLI, addOptionWithInvalidShortName) {
     yeschief::CLI cli("name", "description");
-    ASSERT_THROW(cli.addOption("name,foo", "My option"), std::logic_error);
+    ASSERT_EXIT(
+        cli.addOption("name,foo", "My option"),
+        KilledBySignal(SIGABRT),
+        HasSubstr("Short name of an option can be only one letter")
+    );
 }
 
 TEST(CLI, addOptionMultiple) {
@@ -52,12 +56,16 @@ TEST(CLI, addOptionMultiple) {
 TEST(CLI, addOptionThrowIfAddExisting) {
     yeschief::CLI cli("name", "description");
     cli.addOption("name", "My option");
-    ASSERT_THROW(cli.addOption("name", "My option"), std::logic_error);
+    ASSERT_EXIT(cli.addOption("name", "My option"), KilledBySignal(SIGABRT), HasSubstr("CLI has already this option"));
 }
 
 TEST(CLI, addOptionThowIfInvalidType) {
     yeschief::CLI cli("name", "description");
-    ASSERT_THROW(cli.addOption<yeschief::Fault>("name", "My option"), std::logic_error);
+    ASSERT_EXIT(
+        cli.addOption<yeschief::Fault>("name", "My option"),
+        KilledBySignal(SIGABRT),
+        HasSubstr("Type is not allowed for options")
+    );
 }
 
 TEST(CLI, addOptionWithType) {
@@ -69,7 +77,11 @@ TEST(CLI, addOptionThrowIfCommandAddedBefore) {
     yeschief::CLI cli("name", "description");
     CommandStub command("");
     cli.addCommand(&command);
-    ASSERT_THROW(cli.addOption("name", "My option"), std::logic_error);
+    ASSERT_EXIT(
+        cli.addOption("name", "My option"),
+        KilledBySignal(SIGABRT),
+        HasSubstr("Cannot add an option group to a cli using commands")
+    );
 }
 
 TEST(CLI, addGroupThenAddOption) {
@@ -80,14 +92,18 @@ TEST(CLI, addGroupThenAddOption) {
 TEST(CLI, addGroupThrowIfAddExisting) {
     yeschief::CLI cli("name", "description");
     cli.addGroup("My group").addOption("foo", "bar");
-    ASSERT_THROW(cli.addGroup("My group"), std::logic_error);
+    ASSERT_EXIT(cli.addGroup("My group"), KilledBySignal(SIGABRT), HasSubstr("Group already exists"));
 }
 
 TEST(CLI, addGroupThrowIfCommandAddedBefore) {
     yeschief::CLI cli("name", "description");
     CommandStub command("");
     cli.addCommand(&command);
-    ASSERT_THROW(cli.addGroup("My group"), std::logic_error);
+    ASSERT_EXIT(
+        cli.addGroup("My group"),
+        KilledBySignal(SIGABRT),
+        HasSubstr("Cannot add an option group to a cli using commands")
+    );
 }
 
 TEST(CLI, addCommand) {
@@ -100,7 +116,7 @@ TEST(CLI, addCommandThrowIfExisting) {
     yeschief::CLI cli("name", "description");
     CommandStub command("my-command");
     cli.addCommand(&command);
-    ASSERT_THROW(cli.addCommand(&command), std::logic_error);
+    ASSERT_EXIT(cli.addCommand(&command), KilledBySignal(SIGABRT), HasSubstr("Command already exists"));
 }
 
 TEST(CLI, addCommandMultiple) {
@@ -114,24 +130,34 @@ TEST(CLI, addCommandThrowIfOptionsAddedBefore) {
     yeschief::CLI cli("name", "description");
     cli.addOption("name", "My option");
     CommandStub command("my-command");
-    ASSERT_THROW(cli.addCommand(&command), std::logic_error);
+    ASSERT_EXIT(
+        cli.addCommand(&command), KilledBySignal(SIGABRT), HasSubstr("Cannot add a command to a cli using options")
+    );
 }
 
 TEST(CLI, parsePositionalThrowIfNonExisting) {
     yeschief::CLI cli("name", "description");
-    ASSERT_THROW(cli.parsePositional("hello"), std::logic_error);
+    ASSERT_EXIT(cli.parsePositional("hello"), KilledBySignal(SIGABRT), HasSubstr("Option doesn't exists"));
 }
 
 TEST(CLI, parsePositionalThrowIfRequiredAfterNonRequired) {
     yeschief::CLI cli("name", "description");
     cli.addOption("required", "This is required", {.required = true}).addOption("non-required", "This is not required");
-    ASSERT_THROW(cli.parsePositional("non-required", "required"), std::logic_error);
+    ASSERT_EXIT(
+        cli.parsePositional("non-required", "required"),
+        KilledBySignal(SIGABRT),
+        HasSubstr("Option is required but is placed after a non required one")
+    );
 }
 
 TEST(CLI, parsePositionalThrowIfOptionAfterListOne) {
     yeschief::CLI cli("name", "description");
     cli.addOption<std::vector<int>>("list", "This is a list").addOption("value", "This is not a list");
-    ASSERT_THROW(cli.parsePositional("list", "value"), std::logic_error);
+    ASSERT_EXIT(
+        cli.parsePositional("list", "value"),
+        KilledBySignal(SIGABRT),
+        HasSubstr("Cannot add a new positional argument after one with a list type")
+    );
 }
 
 TEST(CLI, parsePositional) {


### PR DESCRIPTION
Closes #41

Instead of throwing logical_error, use assert.

A special macro assert_message is added. It is a wrapper around assert from assert.h allowing to have a message associated to the assert.

The runtime_error is kept as it catch a bug in the library and not a developer misuse