### PR TITLE
refactor: Use std::format

### DIFF
--- a/src/CLI.cpp
+++ b/src/CLI.cpp
@@ -300,20 +300,25 @@ auto CLI::getValueForOption(const std::shared_ptr<const Option> &option, const s
 }
 
 auto CLI::help(std::ostream &out) const -> void {
-    out << "usage:\n"
-        << "\t" << buildUsageHelp() << "\n"
-        << "\n"
-        << _description << "\n"
-        << "\n";
+    out << std::format(
+        R"(usage:
+  {}
+
+{}
+
+)",
+        buildUsageHelp(),
+        _description
+    );
 
     if (_mode.has_value() && _mode.value() == Mode::COMMANDS) {
         out << "Commands:\n"
             << "\n";
 
         for (const auto &command : _commands | std::ranges::views::values) {
-            out << "\t" << _commands_cli.at(command->getName()).buildUsageHelp() << "\n";
+            out << "  " << _commands_cli.at(command->getName()).buildUsageHelp() << "\n";
             if (! command->getDescription().empty()) {
-                out << "\t\t" << join(split(command->getDescription(), "\n"), "\n\t\t") << "\n";
+                out << "    " << join(split(command->getDescription(), "\n"), "\n    ") << "\n";
             }
             out << "\n";
         }
@@ -329,8 +334,8 @@ auto CLI::help(std::ostream &out) const -> void {
                 << "\n";
 
             for (const auto &option : group._options) {
-                out << "\t" << buildOptionUsageHelp(option) << "\n"
-                    << "\t\t" << join(split(option->description, "\n"), "\n\t\t") << "\n"
+                out << "  " << buildOptionUsageHelp(option) << "\n"
+                    << "    " << join(split(option->description, "\n"), "\n    ") << "\n"
                     << "\n";
             }
         }
@@ -371,10 +376,10 @@ auto CLI::buildPositionalHelp() const -> std::string {
     std::string help
         = "Positional arguments:\n"
           "\n"
-          "\tThese arguments come after options and in the order they are listed here.\n";
+          "  These arguments come after options and in the order they are listed here.\n";
 
     if (_options.at(_positional_options[0])->configuration.required) {
-        help += "\tOnly ";
+        help += "  Only ";
         std::vector<std::string> required;
         for (const auto &option : _positional_options) {
             if (_options.at(option)->configuration.required) {
@@ -392,13 +397,13 @@ auto CLI::buildPositionalHelp() const -> std::string {
     }
 
     for (const auto &option_name : _positional_options) {
-        help += "\t" + toUpper(option_name);
+        help += "  " + toUpper(option_name);
         const auto option = _options.at(option_name);
         if (option->configuration.required) {
             help += " [REQUIRED]";
         }
-        help += "\n\t\t";
-        help += join(split(option->description, "\n"), "\n\t\t") + "\n\n";
+        help += "\n    ";
+        help += join(split(option->description, "\n"), "\n    ") + "\n\n";
     }
 
     return help;

--- a/tests/unit/CLITest.cpp
+++ b/tests/unit/CLITest.cpp
@@ -169,32 +169,27 @@ TEST(CLI, parsePositional) {
 TEST(CLI, helpWithoutOptions) {
     const auto cli = yeschief::CLI(
         "my-program",
-        "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Etiam volutpat vitae felis id ornare. Etiam ac\n"
-        "sollicitudin arcu. Morbi aliquet mauris varius vestibulum gravida. Mauris quis laoreet lectus. Sed sit amet\n"
-        "pharetra tellus. Duis sed egestas dolor. Suspendisse potenti. Proin maximus efficitur tincidunt. "
-        "Pellentesque\n"
-        "eu sodales dui. Vestibulum hendrerit finibus tortor, accumsan tincidunt urna maximus feugiat. Vivamus "
-        "rhoncus\n"
-        "felis lacus, at ultricies ante consequat vitae. Mauris eu dignissim ex, at malesuada dui. Mauris sagittis\n"
-        "mattis accumsan."
+        R"(Lorem ipsum dolor sit amet, consectetur adipiscing elit. Etiam volutpat vitae felis id ornare. Etiam ac
+sollicitudin arcu. Morbi aliquet mauris varius vestibulum gravida. Mauris quis laoreet lectus. Sed sit amet
+pharetra tellus. Duis sed egestas dolor. Suspendisse potenti. Proin maximus efficitur tincidunt. Pellentesque
+eu sodales dui. Vestibulum hendrerit finibus tortor, accumsan tincidunt urna maximus feugiat. Vivamus rhoncus
+felis lacus, at ultricies ante consequat vitae. Mauris eu dignissim ex, at malesuada dui. Mauris sagittis mattis accumsan.)"
     );
     std::stringstream ss;
     cli.help(ss);
     const std::string result(std::istreambuf_iterator<char>(ss), {});
 
     ASSERT_STREQ(
-        "usage:\n"
-        "\tmy-program\n"
-        "\n"
-        "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Etiam volutpat vitae felis id ornare. Etiam ac\n"
-        "sollicitudin arcu. Morbi aliquet mauris varius vestibulum gravida. Mauris quis laoreet lectus. Sed sit amet\n"
-        "pharetra tellus. Duis sed egestas dolor. Suspendisse potenti. Proin maximus efficitur tincidunt. "
-        "Pellentesque\n"
-        "eu sodales dui. Vestibulum hendrerit finibus tortor, accumsan tincidunt urna maximus feugiat. Vivamus "
-        "rhoncus\n"
-        "felis lacus, at ultricies ante consequat vitae. Mauris eu dignissim ex, at malesuada dui. Mauris sagittis\n"
-        "mattis accumsan.\n"
-        "\n",
+        R"(usage:
+  my-program
+
+Lorem ipsum dolor sit amet, consectetur adipiscing elit. Etiam volutpat vitae felis id ornare. Etiam ac
+sollicitudin arcu. Morbi aliquet mauris varius vestibulum gravida. Mauris quis laoreet lectus. Sed sit amet
+pharetra tellus. Duis sed egestas dolor. Suspendisse potenti. Proin maximus efficitur tincidunt. Pellentesque
+eu sodales dui. Vestibulum hendrerit finibus tortor, accumsan tincidunt urna maximus feugiat. Vivamus rhoncus
+felis lacus, at ultricies ante consequat vitae. Mauris eu dignissim ex, at malesuada dui. Mauris sagittis mattis accumsan.
+
+)",
         result.c_str()
     );
 }
@@ -211,42 +206,43 @@ TEST(CLI, helpWithOptions) {
     const std::string result(std::istreambuf_iterator<char>(ss), {});
 
     ASSERT_STREQ(
-        "usage:\n"
-        "\tcli [OPTIONS] --name CHARACTER [NUMBER]\n"
-        "\n"
-        "description\n"
-        "\n"
-        "Positional arguments:\n"
-        "\n"
-        "\tThese arguments come after options and in the order they are listed here.\n"
-        "\tOnly CHARACTER is required.\n"
-        "\n"
-        "\tCHARACTER [REQUIRED]\n"
-        "\t\tA character\n"
-        "\n"
-        "\tNUMBER\n"
-        "\t\tA number\n"
-        "\n"
-        "Options:\n"
-        "\n"
-        "\t--name VALUE, -n VALUE [REQUIRED]\n"
-        "\t\tMy option\n"
-        "\n"
-        "\t--help\n"
-        "\t\tMultiline\n"
-        "\t\thelp message\n"
-        "\n"
-        "\t--number <n>\n"
-        "\t\tA number\n"
-        "\n"
-        "\t--character VALUE [REQUIRED]\n"
-        "\t\tA character\n"
-        "\n"
-        "Special:\n"
-        "\n"
-        "\t--rand\n"
-        "\t\tDisplay a random number\n"
-        "\n",
+        R"(usage:
+  cli [OPTIONS] --name CHARACTER [NUMBER]
+
+description
+
+Positional arguments:
+
+  These arguments come after options and in the order they are listed here.
+  Only CHARACTER is required.
+
+  CHARACTER [REQUIRED]
+    A character
+
+  NUMBER
+    A number
+
+Options:
+
+  --name VALUE, -n VALUE [REQUIRED]
+    My option
+
+  --help
+    Multiline
+    help message
+
+  --number <n>
+    A number
+
+  --character VALUE [REQUIRED]
+    A character
+
+Special:
+
+  --rand
+    Display a random number
+
+)",
         result.c_str()
     );
 }
@@ -260,17 +256,18 @@ TEST(CLI, helpWithCommands) {
     const std::string result(std::istreambuf_iterator<char>(ss), {});
 
     ASSERT_STREQ(
-        "usage:\n"
-        "\tcli [COMMAND] [OPTIONS]\n"
-        "\n"
-        "description\n"
-        "\n"
-        "Commands:\n"
-        "\n"
-        "\tmy-command [OPTIONS]\n"
-        "\t\tStub class for Command.\n"
-        "\t\tDescription on another line.\n"
-        "\n",
+        R"(usage:
+  cli [COMMAND] [OPTIONS]
+
+description
+
+Commands:
+
+  my-command [OPTIONS]
+    Stub class for Command.
+    Description on another line.
+
+)",
         result.c_str()
     );
 }

--- a/tests/unit/HelpCommandTest.cpp
+++ b/tests/unit/HelpCommandTest.cpp
@@ -36,17 +36,18 @@ TEST(HelpCommand, runWithEmptyResultsDisplayFullHelp) {
     ASSERT_EQ(0, help.run(yeschief::CLIResults({})));
     const auto output = internal::GetCapturedStdout();
     ASSERT_STREQ(
-        "usage:\n"
-        "\tname [COMMAND] [OPTIONS]\n"
-        "\n"
-        "description\n"
-        "\n"
-        "Commands:\n"
-        "\n"
-        "\thelp [OPTIONS] [COMMAND]\n"
-        "\t\tDisplay this help message\n"
-        "\t\tWhen COMMAND is given, display help for this command\n"
-        "\n",
+        R"(usage:
+  name [COMMAND] [OPTIONS]
+
+description
+
+Commands:
+
+  help [OPTIONS] [COMMAND]
+    Display this help message
+    When COMMAND is given, display help for this command
+
+)",
         output.c_str()
     );
 }
@@ -62,17 +63,18 @@ TEST(HelpCommand, runWithUnknownCommandDisplayFullHelp) {
     ASSERT_EQ(1, help.run(yeschief::CLIResults(option_values)));
     const auto output = internal::GetCapturedStdout();
     ASSERT_STREQ(
-        "usage:\n"
-        "\tname [COMMAND] [OPTIONS]\n"
-        "\n"
-        "description\n"
-        "\n"
-        "Commands:\n"
-        "\n"
-        "\thelp [OPTIONS] [COMMAND]\n"
-        "\t\tDisplay this help message\n"
-        "\t\tWhen COMMAND is given, display help for this command\n"
-        "\n",
+        R"(usage:
+  name [COMMAND] [OPTIONS]
+
+description
+
+Commands:
+
+  help [OPTIONS] [COMMAND]
+    Display this help message
+    When COMMAND is given, display help for this command
+
+)",
         output.c_str()
     );
 }
@@ -90,17 +92,18 @@ TEST(HelpCommand, runWithCommandDisplayCommandHelp) {
     ASSERT_EQ(0, help.run(yeschief::CLIResults(option_values)));
     const auto output = internal::GetCapturedStdout();
     ASSERT_STREQ(
-        "usage:\n"
-        "\tmy-command [OPTIONS]\n"
-        "\n"
-        "Stub class for Command.\n"
-        "Description on another line.\n"
-        "\n"
-        "Options:\n"
-        "\n"
-        "\t--exit VALUE\n"
-        "\t\tExit code of command\n"
-        "\n",
+        R"(usage:
+  my-command [OPTIONS]
+
+Stub class for Command.
+Description on another line.
+
+Options:
+
+  --exit VALUE
+    Exit code of command
+
+)",
         output.c_str()
     );
 }


### PR DESCRIPTION
Closes #43

Only one place has a meaning of replacing multiple out by one format. Other places have too many conditions to be efficient with one format

Took the oportunity to replace all tabs by only 2 spaces + use raw string literal R"()"